### PR TITLE
Appveyor: Check the MSYS2 mirrorlist and use the one that works.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,22 +10,22 @@ environment:
       - MINGW_VERSION: mingw32
         ARCH: i686
 
-matrix:
-    fast_finish: true
-
 build_script:
     - cd C:\projects\scopy-mingw-build-deps
-    - cmd: C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U http://repo.msys2.org/msys/x86_64/pacman-5.2.2-1-x86_64.pkg.tar.xz"
-    - cmd: C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
-    - cmd: C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
-    - cmd: C:\msys64\usr\bin\bash -lc "pacman-key --verify msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz{.sig,}"
+    - C:\msys64\usr\bin\bash download_old_deps.sh %ARCH% %MINGW_VERSION%
+    - cmd: C:\msys64\usr\bin\bash -lc "cd /c/projects/scopy-mingw-build-deps/old_msys_deps_%MINGW_VERSION%; pacman --noconfirm -U pacman-5.2.2-1-x86_64.pkg.tar.xz"
+   # - cmd: C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
+   # - cmd: C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
+    - cmd: C:\msys64\usr\bin\bash -lc "cd /c/projects/scopy-mingw-build-deps/old_msys_deps_%MINGW_VERSION%; pacman-key --verify msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz{.sig,}"
     - cmd: C:\msys64\usr\bin\bash -lc "pacman-key --populate"
-    - cmd: C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
+    - cmd: C:\msys64\usr\bin\bash -lc "cd /c/projects/scopy-mingw-build-deps/old_msys_deps_%MINGW_VERSION%; pacman --noconfirm -U msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
     - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Syu"
+
     - C:\msys64\usr\bin\bash build.sh
     - echo "### Push artifacts ... "
     - appveyor PushArtifact c:\projects\scopy-mingw-build-deps\scopy-%MINGW_VERSION%-build-deps-pacman.txt
     - appveyor PushArtifact c:\projects\scopy-mingw-build-deps\scopy-%MINGW_VERSION%-build-deps.tar.xz
+    - appveyor PushArtifact c:\projects\scopy-mingw-build-deps\old-msys-build-deps-%MINGW_VERSION%.tar.xz
 
 #on_finish:
 #      - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/build.sh
+++ b/build.sh
@@ -66,10 +66,11 @@ PACMAN_SYNC_DEPS="
 	mingw-w64-$ARCH-doxygen\
 "
 
+
 PACMAN_REPO_DEPS="
-http://repo.msys2.org/mingw/$ARCH/mingw-w64-$ARCH-libusb-1.0.21-2-any.pkg.tar.xz \
-http://repo.msys2.org/mingw/$ARCH/mingw-w64-$ARCH-boost-1.72.0-3-any.pkg.tar.zst \
-http://repo.msys2.org/mingw/$ARCH/mingw-w64-$ARCH-qt5-5.14.2-3-any.pkg.tar.zst \
+${WORKDIR}/old_msys_deps_${MINGW_VERSION}/mingw-w64-$ARCH-libusb-1.0.21-2-any.pkg.tar.xz \
+${WORKDIR}/old_msys_deps_${MINGW_VERSION}/mingw-w64-$ARCH-boost-1.72.0-3-any.pkg.tar.zst \
+${WORKDIR}/old_msys_deps_${MINGW_VERSION}/mingw-w64-$ARCH-qt5-5.14.2-3-any.pkg.tar.zst \
 "
 
 echo "### Installing dependencies ... "

--- a/download_old_deps.sh
+++ b/download_old_deps.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+ARCH="$1"
+MINGW_VERSION="$2"
+
+PACKAGES="libusb boost qt5 breakpad"
+libusb_VER="1.0.21-2"
+boost_VER="1.72.0-3"
+qt5_VER="5.14.2-3"
+breakpad_VER="git-r1680.70914b2d-1"
+
+export PATH=/bin:/usr/bin:/${MINGW_VERSION}/bin:/c/Program\ Files/Git/cmd:/c/Windows/System32
+mirrorlist=$( cat /etc/pacman.d/mirrorlist.msys | grep "Server = " | cut -d ' ' -f3 | /c/msys64/usr/bin/rev | cut -d '/' -f4- | /c/msys64/usr/bin/rev )
+mkdir -p old_msys_deps_$MINGW_VERSION && cd old_msys_deps_$MINGW_VERSION
+
+PAK_TYPE="mingw"
+PAK_ARCH="any"
+for PAK in $PACKAGES
+do
+	PAK_VER="$PAK"_VER
+	if [[ $PAK_TYPE == "mingw" ]]; then
+		PAK_NAME=mingw-w64-$ARCH-$PAK-${!PAK_VER}-$PAK_ARCH
+	else
+		PAK_NAME=$PAK-${!PAK_VER}-$PAK_ARCH
+	fi
+
+	for MSYS_MIRROR in $mirrorlist
+	do
+		EXT="xz"
+		URL=$MSYS_MIRROR/$PAK_TYPE/$ARCH/$PAK_NAME.pkg.tar.$EXT
+		if curl --output /dev/null --silent --head --fail "$URL"; then
+			echo "FOUND: " $PAK-${!PAK_VER} " on " $MSYS_MIRROR
+			wget "$URL"
+			break
+		else
+			EXT="zst"
+			URL=$MSYS_MIRROR/$PAK_TYPE/$ARCH/$PAK_NAME.pkg.tar.$EXT
+			if curl --output /dev/null --silent --head --fail "$URL"; then
+				echo "FOUND: " $PAK-${!PAK_VER} " on " $MSYS_MIRROR
+				wget "$URL"
+				break
+			else
+				echo "NOT FOUND: " $PAK-${!PAK_VER} " on " $MSYS_MIRROR " Trying other mirrors."
+			fi
+		fi
+	done
+done
+
+
+#TEMP TODO:remove
+#These are temporary until some MSYS2 signature issues get fixed
+TEMP_URLS="http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz \
+http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig \
+http://repo.msys2.org/msys/x86_64/pacman-5.2.2-1-x86_64.pkg.tar.xz"
+
+for URL in $TEMP_URLS
+do
+	for MSYS_MIRROR in $mirrorlist
+	do
+		if curl --output /dev/null --silent --head --fail "$URL"; then
+			echo "FOUND: " $URL " on " $MSYS_MIRROR
+			wget "$URL"
+			break
+		else
+			echo "NOT FOUND: " $PAK-${!PAK_VER} " on " $MSYS_MIRROR " Trying other mirrors."
+		fi
+	done
+done
+
+cd ..
+tar cavf old-msys-build-deps-$MINGW_VERSION.tar.xz old_msys_deps_$MINGW_VERSION

--- a/msys_mirrors.sh
+++ b/msys_mirrors.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/bash.exe
+PACMAN_INIT="$1"
+
+export PATH=/bin:/usr/bin:/${MINGW_VERSION}/bin:/c/Program\ Files/Git/cmd:/c/Windows/System32
+mirrorlist=$( cat /etc/pacman.d/mirrorlist.msys | grep "Server = " | cut -d ' ' -f3 | /c/msys64/usr/bin/rev | cut -d '/' -f4- | /c/msys64/usr/bin/rev )
+for m in $mirrorlist
+do
+	response=$(curl -Is $m | grep HTTP | cut -d ' ' -f2)
+	if [[ $response != "" ]]
+	then
+	    MSYS_MIRROR=$m
+		break
+	fi
+done
+export MSYS_MIRROR=$MSYS_MIRROR
+
+if [ "$PACMAN_INIT" == "true" ] ; then
+		pacman --noconfirm -U $MSYS_MIRROR/msys/x86_64/pacman-5.2.2-1-x86_64.pkg.tar.xz
+		curl -O $MSYS_MIRROR/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz
+		curl -O $MSYS_MIRROR/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig
+		pacman-key --verify msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz{.sig,}
+		pacman-key --populate
+		pacman --noconfirm -U msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz
+fi


### PR DESCRIPTION
The default mirror is "repo.msys2.org". If that fails, we make the build
work with the next link in the list.

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>