### PR TITLE
Appveyor: Use mingw64/bin/windres as RC compiler for 64 bit.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -40,7 +40,7 @@ if [ ${ARCH} == "i686" ]
 then
 	RC_COMPILER_OPT="-DCMAKE_RC_COMPILER=/c/windres.exe"
 else
-	RC_COMPILER_OPT=""
+	RC_COMPILER_OPT="-DCMAKE_RC_COMPILER=/c/msys64/mingw64/bin/windres.exe"
 fi
 install_deps() {
 echo "### Download and installed precompiled GNURadio ... "


### PR DESCRIPTION
Appveyor build failed because the RC compiler detection failed.
This might be caused by the CMake package update (checked repo.msys2.org and the update was done 2 days ago, when the builds started failing).
CMake does not detect an appropriate compiler for RC, so we point it to the right path.

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>